### PR TITLE
Support macOS in tmux status and bluetooth scripts

### DIFF
--- a/config/tmux/scripts/bluetooth-menu.sh
+++ b/config/tmux/scripts/bluetooth-menu.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+OS=$(uname)
+
 ESC=$'\e'
 RESET="${ESC}[0m"
 BOLD="${ESC}[1m"
@@ -11,12 +13,101 @@ show_cursor() { printf '%s' "${ESC}[?25h"; }
 
 trap 'show_cursor' EXIT
 
-bt_cmd() { bluetoothctl "$@" 2>/dev/null; }
-bt_powered() { bt_cmd show | grep -q "Powered: yes"; }
-
 MENU_RESULT=0
 SELECTED_MAC=""
 
+# ---- Bluetooth backend (OS-specific) ----------------------------------------
+# Each backend exposes:
+#   bt_powered            -> exit 0 if controller is on
+#   bt_power_on / bt_power_off
+#   bt_devices <filter>   -> prints "MAC<TAB>Name" lines (filter: Paired|Connected)
+#   bt_scan <seconds>     -> scans, then prints discovered "MAC<TAB>Name" lines
+#   bt_connect / bt_disconnect / bt_pair <MAC>
+
+if [ "$OS" = "Darwin" ]; then
+    if ! command -v blueutil >/dev/null 2>&1; then
+        printf '\n  blueutil is not installed.\n\n  Install it with:  brew install blueutil\n\n'
+        printf '  Press any key to close.'
+        IFS= read -rsn1 _
+        exit 1
+    fi
+
+    parse_blueutil() {
+        # Reads blueutil device lines on stdin, emits "MAC<TAB>Name".
+        local line mac name
+        while IFS= read -r line; do
+            mac=${line#address: }; mac=${mac%%,*}
+            case "$line" in
+                *'name: "'*) name=${line#*name: \"}; name=${name%%\"*} ;;
+                *) name=$mac ;;
+            esac
+            [ -n "$mac" ] && printf '%s\t%s\n' "$mac" "$name"
+        done
+    }
+
+    bt_powered() { [ "$(blueutil --power 2>/dev/null)" = "1" ]; }
+    bt_power_on() { blueutil --power 1 2>/dev/null; }
+    bt_power_off() { blueutil --power 0 2>/dev/null; }
+
+    bt_devices() {
+        local flag=--paired
+        [ "$1" = "Connected" ] && flag=--connected
+        blueutil "$flag" 2>/dev/null | parse_blueutil
+    }
+
+    bt_scan() {
+        local dur="$1" tmp pid
+        tmp=$(mktemp)
+        blueutil --inquiry "$dur" >"$tmp" 2>/dev/null &
+        pid=$!
+        for ((i=dur; i>0; i--)); do
+            printf "\r  Scanning... %ds " "$i"
+            sleep 1
+        done
+        wait "$pid" 2>/dev/null
+        parse_blueutil <"$tmp" | awk -F'\t' '!seen[$1]++'
+        rm -f "$tmp"
+    }
+
+    bt_connect() { blueutil --connect "$1" 2>/dev/null; }
+    bt_disconnect() { blueutil --disconnect "$1" 2>/dev/null; }
+    bt_pair() { blueutil --pair "$1" 2>/dev/null; }
+else
+    if ! command -v bluetoothctl >/dev/null 2>&1; then
+        printf '\n  bluetoothctl is not installed.\n\n  Press any key to close.'
+        IFS= read -rsn1 _
+        exit 1
+    fi
+
+    bt_powered() { bluetoothctl show 2>/dev/null | grep -q "Powered: yes"; }
+    bt_power_on() { bluetoothctl power on >/dev/null 2>&1; }
+    bt_power_off() { bluetoothctl power off >/dev/null 2>&1; }
+
+    bt_devices() {
+        bluetoothctl devices "$1" 2>/dev/null | grep "^Device " | while read -r _ mac rest; do
+            printf '%s\t%s\n' "$mac" "$rest"
+        done
+    }
+
+    bt_scan() {
+        local dur="$1" pid
+        bluetoothctl scan on >/dev/null 2>&1 &
+        pid=$!
+        for ((i=dur; i>0; i--)); do
+            printf "\r  Scanning... %ds " "$i"
+            sleep 1
+        done
+        kill "$pid" 2>/dev/null
+        bluetoothctl scan off >/dev/null 2>&1
+        bt_devices ""
+    }
+
+    bt_connect() { bluetoothctl connect "$1" >/dev/null 2>&1; }
+    bt_disconnect() { bluetoothctl disconnect "$1" >/dev/null 2>&1; }
+    bt_pair() { bluetoothctl pair "$1" >/dev/null 2>&1; }
+fi
+
+# ---- UI ---------------------------------------------------------------------
 run_menu() {
     local title="$1"; shift
     local -a items=("$@")
@@ -63,7 +154,7 @@ show_message() {
 select_device() {
     local filter="$1" title="$2"
     local raw_lines
-    raw_lines=$(bt_cmd devices "$filter" | grep "^Device" | sed 's/^Device //')
+    raw_lines=$(bt_devices "$filter")
 
     if [ -z "$raw_lines" ]; then
         show_message "No devices found." 2
@@ -71,9 +162,9 @@ select_device() {
     fi
 
     local -a names=() macs=()
-    while IFS= read -r line; do
-        macs+=("$(echo "$line" | awk '{print $1}')")
-        names+=("$(echo "$line" | cut -d' ' -f2-)")
+    while IFS=$'\t' read -r mac name; do
+        macs+=("$mac")
+        names+=("$name")
     done <<< "$raw_lines"
 
     run_menu "$title" "${names[@]}" || return 1
@@ -82,10 +173,10 @@ select_device() {
 
 toggle_power() {
     if bt_powered; then
-        bt_cmd power off
+        bt_power_off
         show_message "Bluetooth disabled."
     else
-        bt_cmd power on
+        bt_power_on
         show_message "Bluetooth enabled."
     fi
 }
@@ -94,7 +185,7 @@ connect_device() {
     select_device Paired "Connect to device" || return
     printf '\033[2J\033[H'
     printf "\n  Connecting...\n"
-    bt_cmd connect "$SELECTED_MAC"
+    bt_connect "$SELECTED_MAC"
     sleep 2
 }
 
@@ -102,7 +193,7 @@ disconnect_device() {
     select_device Connected "Disconnect device" || return
     printf '\033[2J\033[H'
     printf "\n  Disconnecting...\n"
-    bt_cmd disconnect "$SELECTED_MAC"
+    bt_disconnect "$SELECTED_MAC"
     sleep 1
 }
 
@@ -115,35 +206,27 @@ scan_pair() {
     hide_cursor
     printf '\033[2J\033[H'
     printf "\n"
-    bluetoothctl scan on >/dev/null 2>&1 &
-    local scan_pid=$!
-    for i in $(seq 8 -1 1); do
-        printf "\r  Scanning... %ds " "$i"
-        sleep 1
-    done
-    kill "$scan_pid" 2>/dev/null
-    bt_cmd scan off >/dev/null 2>&1
+    local raw_lines
+    raw_lines=$(bt_scan 8)
     printf "\r  Scan complete.        \n"
     show_cursor
 
-    local raw_lines
-    raw_lines=$(bt_cmd devices | grep "^Device" | sed 's/^Device //')
     if [ -z "$raw_lines" ]; then
         show_message "No devices found." 2
         return
     fi
 
     local -a names=() macs=()
-    while IFS= read -r line; do
-        macs+=("$(echo "$line" | awk '{print $1}')")
-        names+=("$(echo "$line" | cut -d' ' -f2-)")
+    while IFS=$'\t' read -r mac name; do
+        macs+=("$mac")
+        names+=("$name")
     done <<< "$raw_lines"
 
     run_menu "Pair device" "${names[@]}" || return
     local mac="${macs[$MENU_RESULT]}"
     printf '\033[2J\033[H'
     printf "\n  Pairing...\n"
-    bt_cmd pair "$mac"
+    bt_pair "$mac"
     sleep 3
 }
 

--- a/config/tmux/scripts/status.sh
+++ b/config/tmux/scripts/status.sh
@@ -2,7 +2,20 @@
 
 CONFIG="${BASH_SOURCE%/*}/status.conf"
 
+OS=$(uname)
+
 gadget_wlan() {
+    if [ "$OS" = "Darwin" ]; then
+        local dev
+        dev=$(networksetup -listallhardwareports 2>/dev/null | awk '/Wi-Fi/{getline; print $2; exit}')
+        [ -z "$dev" ] && dev=en0
+        if networksetup -getairportpower "$dev" 2>/dev/null | grep -q ": On"; then
+            echo "WLAN: #[fg=colour2]ON#[fg=colour7]"
+        else
+            echo "WLAN: #[fg=colour1]OFF#[fg=colour7]"
+        fi
+        return
+    fi
     if rfkill list wifi 2>/dev/null | grep -q "Soft blocked: yes\|Hard blocked: yes"; then
         echo "WLAN: #[fg=colour1]OFF#[fg=colour7]"
     else
@@ -11,6 +24,17 @@ gadget_wlan() {
 }
 
 gadget_bluetooth() {
+    if [ "$OS" = "Darwin" ]; then
+        local state
+        state=$(system_profiler SPBluetoothDataType 2>/dev/null | awk '/State:/{print $2; exit}')
+        [ -z "$state" ] && return
+        if [ "$state" = "On" ]; then
+            echo "BT: #[fg=colour2]ON#[fg=colour7]"
+        else
+            echo "BT: #[fg=colour1]OFF#[fg=colour7]"
+        fi
+        return
+    fi
     rfkill list bluetooth 2>/dev/null | grep -q . || return
     if rfkill list bluetooth 2>/dev/null | grep -q "Soft blocked: yes\|Hard blocked: yes"; then
         echo "BT: #[fg=colour1]OFF#[fg=colour7]"
@@ -20,6 +44,26 @@ gadget_bluetooth() {
 }
 
 gadget_battery() {
+    if [ "$OS" = "Darwin" ]; then
+        local line percent time state fmt
+        line=$(pmset -g batt 2>/dev/null | grep "InternalBattery" | head -1)
+        [ -z "$line" ] && return
+        percent=$(echo "$line" | grep -oE '[0-9]+%' | tr -d '%')
+        [ -z "$percent" ] && return
+        state=$(echo "$line" | awk -F';' '{gsub(/^[ \t]+/,"",$2); print $2}')
+        time=$(echo "$line" | grep -oE '[0-9]+:[0-9]+' | head -1)
+        [ "$percent" -le 20 ] && colour=colour1 || { [ "$percent" -le 50 ] && colour=colour3 || colour=colour2; }
+        if [ "$state" = "charged" ] || [ -z "$time" ] || [ "$time" = "0:00" ]; then
+            echo "BAT: #[fg=$colour]${percent}%#[fg=colour7]"
+        else
+            local h m
+            h=$(echo "$time" | cut -d: -f1)
+            m=$(echo "$time" | cut -d: -f2)
+            [ "$h" -gt 0 ] 2>/dev/null && fmt="${h}h ${m}m" || fmt="${m}m"
+            echo "BAT: #[fg=$colour]${percent}%#[fg=colour7] - ${fmt}"
+        fi
+        return
+    fi
     output=$(acpi -b 2>/dev/null | grep -v -i "unavailable" | head -1)
     [ -z "$output" ] && return
     percent=$(echo "$output" | grep -oP '\d+(?=%)')
@@ -38,6 +82,16 @@ gadget_battery() {
 }
 
 gadget_cpu() {
+    if [ "$OS" = "Darwin" ]; then
+        local idle percent
+        idle=$(top -l 1 -n 0 2>/dev/null | awk '/CPU usage/{for(i=1;i<=NF;i++) if($i=="idle"){gsub(/%/,"",$(i-1)); print $(i-1)}}')
+        [ -z "$idle" ] && return
+        percent=$(printf '%.0f' "$(echo "100 - $idle" | bc -l 2>/dev/null)")
+        [ -z "$percent" ] && return
+        [ "$percent" -ge 80 ] && colour=colour1 || { [ "$percent" -ge 50 ] && colour=colour3 || colour=colour2; }
+        echo "CPU: #[fg=$colour]${percent}%#[fg=colour7]"
+        return
+    fi
     read_stat() { awk '/^cpu /{print $2+$3+$4+$5+$6+$7+$8, $5}' /proc/stat; }
     s1=$(read_stat); sleep 0.5; s2=$(read_stat)
     total=$(($(echo $s2|cut -d' ' -f1) - $(echo $s1|cut -d' ' -f1)))
@@ -48,12 +102,32 @@ gadget_cpu() {
 }
 
 gadget_mem() {
+    if [ "$OS" = "Darwin" ]; then
+        local free percent
+        free=$(memory_pressure 2>/dev/null | awk -F': ' '/free percentage/{gsub(/%/,"",$2); print $2}')
+        [ -z "$free" ] && return
+        percent=$((100 - free))
+        [ "$percent" -ge 85 ] && colour=colour1 || { [ "$percent" -ge 60 ] && colour=colour3 || colour=colour2; }
+        echo "RAM: #[fg=$colour]${percent}%#[fg=colour7]"
+        return
+    fi
     percent=$(awk '/MemTotal/{t=$2} /MemAvailable/{a=$2} END{print int((t-a)*100/t)}' /proc/meminfo)
     [ "$percent" -ge 85 ] && colour=colour1 || { [ "$percent" -ge 60 ] && colour=colour3 || colour=colour2; }
     echo "RAM: #[fg=$colour]${percent}%#[fg=colour7]"
 }
 
 gadget_temp() {
+    if [ "$OS" = "Darwin" ]; then
+        # No built-in CPU temp sensor on macOS; requires osx-cpu-temp (brew).
+        command -v osx-cpu-temp >/dev/null 2>&1 || return
+        local temp int
+        temp=$(osx-cpu-temp 2>/dev/null | grep -oE '[0-9]+\.[0-9]+' | head -1)
+        [ -z "$temp" ] && return
+        int=${temp%.*}
+        [ "$int" -ge 80 ] && colour=colour1 || { [ "$int" -ge 60 ] && colour=colour3 || colour=colour2; }
+        echo "TEMP: #[fg=$colour]${int}°C#[fg=colour7]"
+        return
+    fi
     temp=$(sensors k10temp-pci-00c3 2>/dev/null | grep "Tctl" | grep -oP '\d+\.\d+' | head -1)
     [ -z "$temp" ] && return
     int=${temp%.*}


### PR DESCRIPTION
Make the tmux status bar and bluetooth menu OS-aware so they work on macOS as well as Linux.

## status.sh
Each gadget now branches on `uname`:

| Gadget | Linux | macOS |
|--------|-------|-------|
| wlan | `rfkill` | `networksetup -getairportpower` (auto-detects Wi-Fi device) |
| bluetooth | `rfkill` | `system_profiler SPBluetoothDataType` |
| battery | `acpi` | `pmset -g batt` |
| cpu | `/proc/stat` | `top -l 1` idle → usage |
| mem | `/proc/meminfo` | `memory_pressure` free% → used% |
| temp | `sensors` | `osx-cpu-temp` if installed, else omitted |
| disk | `df /` | `df /` (already cross-platform) |

## bluetooth-menu.sh
Refactored so the menu UI is shared and the Bluetooth backend swaps by OS: `bluetoothctl` on Linux, `blueutil` on macOS. Device listing is tab-separated internally so names with spaces parse correctly. Missing backend tool shows a clear install hint and exits cleanly.

## Notes
- The macOS bluetooth menu requires `blueutil` (`brew install blueutil`). The status bar BT indicator works without it.

## Testing
- Live output verified on macOS: `WLAN: ON | BT: ON | BAT: 100% | CPU: 18% | RAM: 53% | DSK: 6%`
- `bash -n` syntax check passes on both scripts
- Missing-blueutil path verified